### PR TITLE
Fixed __init__.py to work with Python 3 and migrated to setuptools

### DIFF
--- a/gmr/__init__.py
+++ b/gmr/__init__.py
@@ -4,10 +4,10 @@ gmr
 
 Gaussian Mixture Models (GMMs) for clustering and regression in Python.
 """
-from mvn import MVN, plot_error_ellipse
-from gmm import GMM, plot_error_ellipses
-
 
 __version__ = "1.1-git"
 
-__all__ = ["GMM", "MVN", "plot_error_ellipse", "plot_error_ellipses"]
+__all__ = ['gmm', 'mvn', 'utils']
+
+from .mvn import MVN, plot_error_ellipse
+from .gmm import GMM, plot_error_ellipses

--- a/setup.py
+++ b/setup.py
@@ -4,11 +4,13 @@
 # License: BSD 3 clause
 
 from setuptools import setup
+import gmr
+VERSION = gmr.__version__
 
 def setup_package():
     setup(
         name="gmr",
-        version="1.1-git",
+        version=VERSION,
         author="Alexander Fabisch",
         author_email="afabisch@googlemail.com",
         url="https://github.com/AlexanderFabisch/gmr",
@@ -28,7 +30,7 @@ def setup_package():
             "Programming Language :: Python :: 2",
             "Programming Language :: Python :: 2.7",
             "Programming Language :: Python :: 3",
-            "Programming Language :: Python :: 3.3",
+            "Programming Language :: Python :: 3.4",
         ],
         packages=["gmr"],
         requires=["numpy", "scipy"],

--- a/setup.py
+++ b/setup.py
@@ -3,15 +3,12 @@
 # Author: Alexander Fabisch <afabisch@googlemail.com>
 # License: BSD 3 clause
 
-
-from distutils.core import setup
-import gmr
-
+from setuptools import setup
 
 def setup_package():
     setup(
         name="gmr",
-        version=gmr.__version__,
+        version="1.1-git",
         author="Alexander Fabisch",
         author_email="afabisch@googlemail.com",
         url="https://github.com/AlexanderFabisch/gmr",


### PR DESCRIPTION
`__init__.py` had an issue which caused a crash when trying to import the model in Python 3. I also migrated `setup.py` to use setuptools, which has improved functionality (like being able to link your working repository as a package using `setup.py develop`). 