### PR TITLE
Replace code by numpy / scipy functions

### DIFF
--- a/gmr/mvn.py
+++ b/gmr/mvn.py
@@ -2,6 +2,7 @@ import numpy as np
 from .utils import check_random_state, pinvh
 import scipy as sp
 from scipy.stats import chi2
+from scipy.spatial.distance import mahalanobis
 
 
 def invert_indices(n_features, indices):
@@ -285,8 +286,7 @@ class MVN(object):
         d : float
             Squared Mahalanobis distance
         """
-        d = x - self.mean
-        return d.dot(np.linalg.inv(self.covariance)).dot(d)
+        return mahalanobis(x, self.mean, np.linalg.inv(self.covariance)) ** 2
 
     def to_ellipse(self, factor=1.0):
         """Compute error ellipse.

--- a/gmr/mvn.py
+++ b/gmr/mvn.py
@@ -286,6 +286,7 @@ class MVN(object):
         d : float
             Squared Mahalanobis distance
         """
+        self._check_initialized()
         return mahalanobis(x, self.mean, np.linalg.inv(self.covariance)) ** 2
 
     def to_ellipse(self, factor=1.0):

--- a/gmr/mvn.py
+++ b/gmr/mvn.py
@@ -483,7 +483,7 @@ def regression_coefficients(covariance, i1, i2, cov_12=None):
     i2 : array, shape (n_features2,)
         Output feature indices
 
-    cov12 : array, shape (n_features1, n_features2), optional (default: None)
+    cov_12 : array, shape (n_features1, n_features2), optional (default: None)
         Precomputed block of the covariance matrix between input features and
         output features
 

--- a/gmr/mvn.py
+++ b/gmr/mvn.py
@@ -62,6 +62,9 @@ class MVN(object):
         X : array-like, shape (n_samples, n_features)
             Samples from the true function.
 
+        bessels_correction : bool
+            Apply Bessel's correction to the covariance estimate.
+
         Returns
         -------
         self : MVN

--- a/gmr/mvn.py
+++ b/gmr/mvn.py
@@ -1,8 +1,9 @@
 import numpy as np
-from .utils import check_random_state, pinvh
+from .utils import check_random_state
 import scipy as sp
 from scipy.stats import chi2
 from scipy.spatial.distance import mahalanobis
+from scipy.linalg import pinvh
 
 
 def invert_indices(n_features, indices):

--- a/gmr/utils.py
+++ b/gmr/utils.py
@@ -1,5 +1,4 @@
 import numpy as np
-from scipy import linalg
 import numbers
 
 
@@ -21,62 +20,3 @@ def check_random_state(seed):
         return seed
     raise ValueError('%r cannot be used to seed a numpy.random.RandomState'
                      ' instance' % seed)
-
-
-def pinvh(a, cond=None, rcond=None, lower=True):
-    """Compute the (Moore-Penrose) pseudo-inverse of a hermetian matrix.
-
-    Calculate a generalized inverse of a symmetric matrix using its
-    eigenvalue decomposition and including all 'large' eigenvalues.
-
-    Parameters
-    ----------
-    a : array, shape (N, N)
-        Real symmetric or complex hermetian matrix to be pseudo-inverted
-    cond, rcond : float or None
-        Cutoff for 'small' eigenvalues.
-        Singular values smaller than rcond * largest_eigenvalue are considered
-        zero.
-
-        If None or -1, suitable machine precision is used.
-    lower : boolean
-        Whether the pertinent array data is taken from the lower or upper
-        triangle of a. (Default: lower)
-
-    Returns
-    -------
-    B : array, shape (N, N)
-
-    Raises
-    ------
-    LinAlgError
-        If eigenvalue does not converge
-
-    Examples
-    --------
-    >>> import numpy as np
-    >>> a = np.random.randn(9, 6)
-    >>> a = np.dot(a, a.T)
-    >>> B = pinvh(a)
-    >>> np.allclose(a, np.dot(a, np.dot(B, a)))
-    True
-    >>> np.allclose(B, np.dot(B, np.dot(a, B)))
-    True
-
-    """
-    a = np.asarray_chkfinite(a)
-    s, u = linalg.eigh(a, lower=lower)
-
-    if rcond is not None:
-        cond = rcond
-    if cond in [None, -1]:
-        t = u.dtype.char.lower()
-        factor = {'f': 1E3, 'd': 1E6}
-        cond = factor[t] * np.finfo(t).eps
-
-    # unlike svd case, eigh can lead to negative eigenvalues
-    above_cutoff = (abs(s) > cond * np.max(abs(s)))
-    psigma_diag = np.zeros_like(s)
-    psigma_diag[above_cutoff] = 1.0 / s[above_cutoff]
-
-    return np.dot(u * psigma_diag, np.conjugate(u).T)


### PR DESCRIPTION
... as suggested in https://github.com/openjournals/joss-reviews/issues/3054

Some findings:
- [scipy.stats.multivariate_normal.pdf](https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.multivariate_normal.html#scipy.stats.multivariate_normal) is not robust enough to handle singular covariances. In general this package takes care of handling many numerical pitfalls accurately (often in a different way than sklearn's implementation of GMMs by the way) and improved a lot in recent updates. This is a crucial aspect for a robust GMR implementation and it is often not directly supported by scipy and numpy.
- pinvh is part of scipy (now?), it has been replaced
- scipy.spatial.distance.mahalanobis will be used