### PR TITLE
Fix GMM.condition() ValueError with single conditioning value

### DIFF
--- a/gmr/gmm.py
+++ b/gmr/gmm.py
@@ -465,8 +465,10 @@ class GMM(object):
             means[k] = conditioned.mean
             covariances[k] = conditioned.covariance
 
-            marginal_norm_factors[k], marginal_prior_exponents[k] = \
+            norm_factor, exponents = \
                 mvn.marginalize(indices).to_norm_factor_and_exponents(x)
+            marginal_norm_factors[k] = norm_factor
+            marginal_prior_exponents[k] = exponents[0]
 
         priors = _safe_probability_density(
             self.priors * marginal_norm_factors,

--- a/gmr/tests/test_gmm.py
+++ b/gmr/tests/test_gmm.py
@@ -158,6 +158,30 @@ def test_conditional_distribution():
     assert_array_almost_equal(conditional.covariances[1], np.array([[0.3]]))
 
 
+def test_conditional_distribution_input_formats():
+    """Test that GMM.condition accepts various input formats."""
+    random_state = check_random_state(0)
+
+    gmm = GMM(n_components=2, priors=np.array([0.5, 0.5]), means=means,
+              covariances=covariances, random_state=random_state)
+
+    # All these input formats should work and produce the same result
+    y_target = 1.0
+    input_formats = [
+        np.array([y_target]),      # 1D array
+        [y_target],                # list
+        [[y_target]],              # nested list
+        np.array([[y_target]]),    # 2D array
+    ]
+
+    reference = gmm.condition(np.array([1]), np.array([y_target]))
+
+    for x in input_formats:
+        conditional = gmm.condition(np.array([1]), x)
+        assert_array_almost_equal(conditional.means, reference.means)
+        assert_array_almost_equal(conditional.covariances, reference.covariances)
+
+
 def test_sample_confidence_region():
     """Test sampling from confidence region."""
     random_state = check_random_state(0)


### PR DESCRIPTION
## Summary

`GMM.condition()` raises `ValueError: setting an array element with a sequence` when conditioning on a single value. This affects all input formats (`[[val]]`, `[val]`, `np.array(...)`, scalar).

## Root Cause

The `to_norm_factor_and_exponents()` method returns `exponents` as an array of shape `(n_samples,)`. When conditioning on a single value, this is a 1-element array, not a scalar. The original code attempted to assign this array directly to `marginal_prior_exponents[k]` (a scalar slot), causing the error.

## Fix

Extract the scalar value with `exponents[0]` since `condition()` is designed to handle a single conditioning value:

```python
# Before (broken):
marginal_norm_factors[k], marginal_prior_exponents[k] =     mvn.marginalize(indices).to_norm_factor_and_exponents(x)

# After (fixed):
norm_factor, exponents =     mvn.marginalize(indices).to_norm_factor_and_exponents(x)
marginal_norm_factors[k] = norm_factor
marginal_prior_exponents[k] = exponents[0]
```

## Minimal Reproducer

```python
import numpy as np
from gmr import GMM

np.random.seed(42)
data = np.random.randn(100, 2)

gmm = GMM(n_components=2, random_state=42)
gmm.from_samples(data)

# This fails with ValueError before the fix
conditional = gmm.condition([1], [[0.75]])
```

## Testing

- Added `test_conditional_distribution_input_formats()` to verify various input formats work
- All 61 existing tests pass